### PR TITLE
Limit UI scale to prevent overflow on some devices

### DIFF
--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -20,8 +20,9 @@ var tabs_panel: PanelContainer
 
 var android_runtime: JNISingleton
 var is_light_system_bars: bool = false
-
 var status_bar_visible: bool = true
+
+var minimum_content_width : float
 
 func set_system_bar_color(color: Color, override_appearance := false) -> void:
 	if not android_runtime:
@@ -380,8 +381,19 @@ func get_auto_ui_scale() -> float:
 	var base_dpi := 160.0
 	var scale := dpi / base_dpi
 	var blend: float = clamp((dpi - 240.0) / 400.0, 0.0, 1.0)
-	var adjusted_scale: float = lerp(scale, pow(scale, 0.75), blend)
-	return max(adjusted_scale, 1.0)
+	var adjusted_scale: float = max(lerp(scale, pow(scale, 0.75), blend), 1.0)
+	
+	var screen_width := get_tree().root.size.x
+	print("contents_minimum_width: ", minimum_content_width)
+	print("screen_width: ", screen_width)
+	print("adjusted_scale: ", adjusted_scale)
+
+	# Ensure the scale doesn't cause UI overflow.
+	if (screen_width / adjusted_scale) < minimum_content_width:
+		adjusted_scale = screen_width / minimum_content_width
+		print("Adjusted scale due to min content width: ", adjusted_scale)
+
+	return snapped(adjusted_scale, 0.01)
 
 func update_ui_scale() -> void:
 	var window := get_window()

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -89,6 +89,7 @@ func sync_reference_image() ->  void:
 		reference_texture.hide()
 
 func _on_snap_button_toggled(toggled_on: bool) -> void:
+	HandlerGUI.update_ui_scale()
 	Configs.savedata.snap = absf(Configs.savedata.snap) if toggled_on else -absf(Configs.savedata.snap)
 
 func _on_snap_number_edit_value_changed(new_value: float) -> void:

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -197,6 +197,8 @@ func update_layout() -> void:
 			side_panel_vbox.add_child(create_layout_node(side_panel_top[0]))
 		elif not side_panel_bottom.is_empty():
 			side_panel_vbox.add_child(create_layout_node(side_panel_bottom[0]))
+	
+	HandlerGUI.minimum_content_width = get_minimum_size().x
 
 func _on_main_splitter_dragged(offset: int) -> void:
 	Configs.savedata.main_splitter_offset = offset

--- a/src/ui_widgets/settings_content_generic.gd
+++ b/src/ui_widgets/settings_content_generic.gd
@@ -557,9 +557,11 @@ func setup_other_content() -> void:
 	var dropdown_map := {
 		SaveData.ScalingApproach.AUTO: "Auto (%d%%)" % int(auto_scale * 100),
 	}
+	var screen_width := get_tree().root.size.x
 	for approach in all_options.keys():
 		var value: float= all_options[approach]
-		dropdown_map[approach] = "%d%%" % int(value * 100)
+		if ((screen_width / value) >= HandlerGUI.minimum_content_width) && value >= auto_scale/2:
+			dropdown_map[approach] = "%d%%" % int(value * 100)
 	
 	current_setup_setting = "ui_scale"
 	add_dropdown(Translator.translate("UI scale"), dropdown_map.keys(), dropdown_map)


### PR DESCRIPTION
Restrict UI scale based on minimum content width.
Only show valid scale options in settings to avoid UI being too large or too small making it unusable.